### PR TITLE
Update `poppler-data-feedstock` to version `0.4.11`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "poppler-data" %}
-{% set version = "0.4.10" %}
-{% set sha256 = "6e2fcef66ec8c44625f94292ccf8af9f1d918b410d5aa69c274ce67387967b30" %}
+{% set version = "0.4.11" %}
+{% set sha256 = "2cec05cd1bb03af98a8b06a1e22f6e6e1a65b1e2f3816cb3069bb0874825f08c" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,10 +27,12 @@ test:
 
 about:
   home: https://poppler.freedesktop.org/
-  license: Adobe+GPLv2
+  license: GPL-2.0-or-later
   license_family: GPL
   license_file: COPYING
   summary: 'Encoding data for the Poppler PDF manipulation library.'
+  dev_url: https://gitlab.freedesktop.org/poppler/poppler
+  doc_url: https://freedesktop.org/wiki/Software/poppler/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ test:
 
 about:
   home: https://poppler.freedesktop.org/
-  license: GPL-2.0-or-later
+  license: GPL-2.0-or-later and GPL-3.0-or-later and BSD-3-Clause
   license_family: GPL
   license_file: COPYING
   summary: 'Encoding data for the Poppler PDF manipulation library.'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ about:
   license_family: GPL
   license_file: COPYING
   summary: 'Encoding data for the Poppler PDF manipulation library.'
-  dev_url: https://gitlab.freedesktop.org/poppler/poppler
+  dev_url: https://gitlab.freedesktop.org/poppler/poppler-data
   doc_url: https://freedesktop.org/wiki/Software/poppler/
 
 extra:


### PR DESCRIPTION
  `poppler-data` version `0.4.11`
1. - [x] check the upstream
    https://gitlab.freedesktop.org/poppler/poppler-data

2. - [x] check the pinnings

    https://gitlab.freedesktop.org/poppler/poppler-data/-/blob/master/Makefile

    https://gitlab.freedesktop.org/poppler/poppler-data/-/blob/master/CMakeLists.txt

3. - [x] check the changelogs
    
    There was no change log file in the repo, however the commit log was inspected, there were no important breaking changes in the commit section at the time of the review

    https://gitlab.freedesktop.org/poppler/poppler-data/-/commits/master

4. - [x] additional research
    https://github.com/conda-forge/poppler-data-feedstock/issues

    There were no open issues in the upstream at the time of the review

5. - [x] verify dev_url

    https://gitlab.freedesktop.org/poppler/poppler-data

6. - [x] verify doc_url

    https://freedesktop.org/wiki/Software/poppler/

7. - [x] license is spdx compliant

    The previous license was not compliant with spdx, 
    the closest license available was `GPL-2.0-or-later`

8. - [x] license family
9. - [x] verify the build number

    The build number is set to zero
 
10. - [x] verify setuptools

     `setuptools` is not mentioned in the upstream

11. - [x] verify wheel

     `wheel` is not mentioned in the upstream


12. - [x] pip in the test section

     `pip` is not mentioned in the upstream


13. - [x] veriy the test section

Results:
- All checks have passed


Based on the research findings and the results we can conclude
that it is safe to update `poppler-data` to version `0.4.11`
